### PR TITLE
Address part of #11: Fully embrace RFC 8949 encoding indicator syntax

### DIFF
--- a/cbor-diag-parser.abnf
+++ b/cbor-diag-parser.abnf
@@ -30,8 +30,8 @@ bstr            = app-string / sqstr / embedded; app could be any type
 tstr            = DQUOTE *double-quoted DQUOTE
 embedded        = "<<" seq ">>"
 
-array           = "[" spec [item S *("," S item S) OC] "]"
-map             = "{" spec [kp S *("," S kp S) OC] "}"
+array           = "[" spec S [item S *("," S item S) OC] "]"
+map             = "{" spec S [kp S *("," S kp S) OC] "}"
 kp              = item S ":" S item
 
 ; We allow %x09 HT in prose, but not in strings
@@ -47,9 +47,8 @@ OC              = ["," S]
 
 ; check semantically that strings are either all text or all bytes
 ; note that there must be at least one string to distinguish
-streamstring    = "(" spec1 string S *("," S string S) OC ")"
-spec            = ["_" *wordchar S]
-spec1           = "_" S
+streamstring    = "(_" S string S *("," S string S) OC ")"
+spec            = ["_" *wordchar]
 
 double-quoted   = unescaped
                 / "'"

--- a/cbor-diag-parser.abnf
+++ b/cbor-diag-parser.abnf
@@ -45,9 +45,9 @@ comment         = "/" *non-slash "/"
 ; optional trailing comma (ignored)
 OC              = ["," S]
 
+; check semantically that strings are either all text or all bytes
 ; note that there must be at least one string to distinguish
-streamstring    = "(" spec1 tstr S *("," S tstr S) OC ")"
-                / "(" spec1 bstr S *("," S bstr S) OC ")"
+streamstring    = "(" spec1 string S *("," S string S) OC ")"
 spec            = ["_" *wordchar S]
 spec1           = "_" S
 

--- a/cbor-diag-parser.abnf
+++ b/cbor-diag-parser.abnf
@@ -1,7 +1,10 @@
 seq             = S [item S *("," S item S) OC] S
 item            = map / array / tagged
-                / basenumber / decnumber / infin / simple
-                / tstr / bstr / embedded / streamstring
+                / number / simple
+                / string / streamstring
+
+number          = (basenumber / decnumber / infin) spec
+string          = (tstr / bstr) spec
 
 sign            = "+" / "-"
 decnumber       = [sign] 1*DIGIT ["." 1*DIGIT] ["e" [sign] 1*DIGIT]
@@ -18,12 +21,12 @@ simple          = %s"false"
                 / %s"undefined"
                 / %s"simple(" S item S ")"
 uint            = "0" / DIGIT1 *DIGIT
-tagged          = uint "(" S item S ")"
+tagged          = uint spec "(" S item S ")"
 
 app-prefix      = lcalpha *lcalnum ; including h and b64
 app-string      = app-prefix sqstr
 sqstr           = "'" *single-quoted "'"
-bstr            = app-string / sqstr ; app could be any type
+bstr            = app-string / sqstr / embedded; app could be any type
 tstr            = DQUOTE *double-quoted DQUOTE
 embedded        = "<<" seq ">>"
 
@@ -45,8 +48,8 @@ OC              = ["," S]
 ; note that there must be at least one string to distinguish
 streamstring    = "(" spec1 tstr S *("," S tstr S) OC ")"
                 / "(" spec1 bstr S *("," S bstr S) OC ")"
-spec            = S ["_" S]
-spec1           = S "_" S
+spec            = ["_" *wordchar S]
+spec1           = "_" S
 
 double-quoted   = unescaped
                 / "'"
@@ -95,3 +98,4 @@ HEXDIG          = DIGIT / "A" / "B" / "C" / "D" / "E" / "F"
 ; Note: double-quoted strings as in "A" are case-insensitive in ABNF
 lcalpha         = %x61-7A ; a-z
 lcalnum         = lcalpha / DIGIT
+wordchar        = "_" / lcalnum / %x41-5a ; [_a-z0-9A-Z]


### PR DESCRIPTION
* Remove spurious spaces in front of them
* Allow them behind all strings and numbers
* Allow then right after the tag number
* Add embedded to the bstr choice (So now also allow them in streamstring)

Encoding Indicator within streamstring addressed in commit below.
With app-string in the picture, there no longer is a syntactic way to
check that the chunks of streamstrings are all text or all bytes.
