### PR TITLE
Allow .3 and 3. for decimal and hex float

### DIFF
--- a/cbor-diag-parser.abnf
+++ b/cbor-diag-parser.abnf
@@ -11,9 +11,11 @@ string          = string1e *(S string1e)
 
 number          = (basenumber / decnumber / infin) spec
 sign            = "+" / "-"
-decnumber       = [sign] 1*DIGIT ["." 1*DIGIT] ["e" [sign] 1*DIGIT]
+decnumber       = [sign] (1*DIGIT ["." *DIGIT] / "." 1*DIGIT)
+                         ["e" [sign] 1*DIGIT]
 basenumber      = [sign] "0" ("x" 1*HEXDIG
-                              [["." 1*HEXDIG] "p" [sign] 1*DIGIT]
+                              [["." *HEXDIG] "p" [sign] 1*DIGIT]
+                            / "x" "." 1*HEXDIG "p" [sign] 1*DIGIT
                             / "o" 1*ODIGIT
                             / "b" 1*BDIGIT)
 infin           = %s"Infinity"

--- a/draft-ietf-cbor-edn-literals.md
+++ b/draft-ietf-cbor-edn-literals.md
@@ -790,7 +790,8 @@ The following additional items should help in the interpretation:
 * `decnumber` stands for an integer in the usual decimal notation, unless at
   least one of the optional parts starting with "." and "e" are
   present, in which case it stands for a floating point value in the
-  usual decimal notation.
+  usual decimal notation.  Note that the grammar now allows `3.` for
+  `3.0` and `.3` for `0.3` (also for hexadecimal floating point below).
 * `basenumber` stands for an integer in the usual base 16/hexadecimal
   ("0x"), base 8/octal ("0o"), or base 2/binary ("0b") notation, unless the
   optional part containing a "p" is present, in which case it stands


### PR DESCRIPTION
(... as opposed to requiring 0.3 and 3.0)