### PR TITLE
Close #37: Superfluous S in ABNF

### DIFF
--- a/cbor-diag-parser.abnf
+++ b/cbor-diag-parser.abnf
@@ -1,4 +1,4 @@
-seq             = S [item S *("," S item S) OC] S
+seq             = S [item S *("," S item S) OC]
 one-item        = S item S
 item            = map / array / tagged
                 / number / simple


### PR DESCRIPTION
This change should be innocuous (i.e., it doesn't actually matter if you pick it up or not), but will reduce confusion.