### PR TITLE
alternate single-pass ABNF

### DIFF
--- a/cbor-diag-parser.abnf
+++ b/cbor-diag-parser.abnf
@@ -73,7 +73,7 @@ partial-time    = time-hour ":" time-minute ":" time-second
                   [time-secfrac]
 
 ; app-string ip
-ip              = (%s"dt" / %s"DT") SQUOTE inside-ip SQUOTE
+ip              = (%s"ip" / %s"IP") SQUOTE inside-ip SQUOTE
 inside-ip       = IPaddress ["/" uint]
 IPaddress       = IPv4address/ IPv6address
 

--- a/cbor-diag-parser.abnf
+++ b/cbor-diag-parser.abnf
@@ -36,13 +36,17 @@ bstr            = embedded / sqstr / known-app-str / ext-app-str
 ext-app-str     = app-prefix sqstr
 known-app-str   = h / b64 / ip / dt
 
+invalid-app-str = *single-quoted ; error parsing the grammar of this app-str
+
 ; app-string h
 h               = %s"h" SQUOTE inside-h SQUOTE
-inside-h        = S *(HEXDIG S HEXDIG S / ellipsis S) S
+inside-h        = valid-h / invalid-app-str
+valid-h         = S *(HEXDIG S HEXDIG S / ellipsis S) S
 
 ; app-string b64
 b64             = %s"b64" SQUOTE inside-b64 SQUOTE
-inside-b64      = B *b64-4  [ b64-3 / b64-2 ]
+inside-b64      = valid-b64 / invalid-app-str
+valid-b64       = B *b64-4  [ b64-3 / b64-2 ]
 b64-4           = 4(b64dig B)
 b64-3           = 3(b64dig B) ["="] B
 b64-2           = 2(b64dig B) ["=" B "="] B
@@ -51,7 +55,8 @@ B               = *iblank *(hash-comment *iblank)
 iblank          = %x0A / %x20  ; Not HT or CR (gone)
 
 ; app-string dt
-dt              = (%s"dt" / %s"DT") SQUOTE date-time SQUOTE
+dt              = (%s"dt" / %s"DT") SQUOTE inside-dt SQUOTE
+inside-dt       = date-time / invalid-app-str
 full-date       = date-fullyear "-" date-month "-" date-mday
 full-time       = partial-time time-offset
 date-time       = full-date "T" full-time
@@ -72,7 +77,8 @@ partial-time    = time-hour ":" time-minute ":" time-second
 
 ; app-string ip
 ip              = (%s"ip" / %s"IP") SQUOTE inside-ip SQUOTE
-inside-ip       = IPaddress ["/" uint]
+inside-ip       = valid-ip / invalid-app-str
+valid-ip        = IPaddress ["/" uint]
 IPaddress       = IPv4address/ IPv6address
 
 ; ABNF from RFC 3986, re-arranged for PEG compatibility:
@@ -119,6 +125,7 @@ safe-unescaped  =  %x0D ; carriage return
                  / %xE000-10FFFF
 slash-escaped   = "\" ( SQUOTE / "/" / escapable )
 hash-escaped    = "\" ( SQUOTE / "\" )
+; h'AA#foo'
 
 ; optional trailing comma (ignored)
 OC              = ["," S]

--- a/cbor-diag-parser.abnf
+++ b/cbor-diag-parser.abnf
@@ -41,7 +41,7 @@ invalid-app-str = *single-quoted ; error parsing the grammar of this app-str
 ; app-string h
 h               = %s"h" SQUOTE inside-h SQUOTE
 inside-h        = valid-h / invalid-app-str
-valid-h         = S *(HEXDIG S HEXDIG S / ellipsis S) S
+valid-h         = SQS *(HEXDIG SQS HEXDIG SQS / ellipsis SQS) SQS
 
 ; app-string b64
 b64             = %s"b64" SQUOTE inside-b64 SQUOTE
@@ -51,7 +51,7 @@ b64-4           = 4(b64dig B)
 b64-3           = 3(b64dig B) ["="] B
 b64-2           = 2(b64dig B) ["=" B "="] B
 b64dig          = ALPHA / DIGIT / "-" / "_" / "+" / "/"
-B               = *iblank *(hash-comment *iblank)
+B               = *iblank *(sq-hash-comment *iblank)
 iblank          = %x0A / %x20  ; Not HT or CR (gone)
 
 ; app-string dt
@@ -112,10 +112,17 @@ kp              = item S ":" S item
 ; We allow %x09 HT in prose, but not in strings
 blank           = %x09 / %x0A / %x0D / %x20
 S               = *blank *(comment *blank)
+; SQS is whitespace/comments inside some single quoted strings
+SQS             = *blank *(safe-comment *blank)
 comment         = slash-comment / hash-comment
+safe-comment    = sq-slash-comment / sq-hash-comment
 slash-comment   = "/" *safe-non-slash "/"
-hash-comment    = "#" *safe-non-lf LF
+hash-comment    = "#" *non-lf LF
+sq-slash-comment= "/" *safe-non-slash "/"
+sq-hash-comment = "#" *safe-non-lf LF
+non-slash       = safe-unescaped / LF / SQUOTE / slash-escaped
 safe-non-slash  = safe-unescaped / LF / slash-escaped
+non-lf          = safe-unescaped / "/" / SQUOTE /hash-escaped
 safe-non-lf     = safe-unescaped / "/" / hash-escaped
 safe-unescaped  =  %x0D ; carriage return
                  / %x20-26   ; omit 0x27 '
@@ -125,7 +132,6 @@ safe-unescaped  =  %x0D ; carriage return
                  / %xE000-10FFFF
 slash-escaped   = "\" ( SQUOTE / "/" / escapable )
 hash-escaped    = "\" ( SQUOTE / "\" )
-; h'AA#foo'
 
 ; optional trailing comma (ignored)
 OC              = ["," S]

--- a/cbor-diag-parser.abnf
+++ b/cbor-diag-parser.abnf
@@ -48,7 +48,7 @@ b64             = %s"b64" SQUOTE inside-b64 SQUOTE
 inside-b64      = B *b64_4  [ b64_3 / b64_2 ]
 b64_4           = 4(b64dig B)
 b64_3           = 3(b64dig B) ["="] B
-b64_2           = 2(b64dig B) ["=="] B
+b64_2           = 2(b64dig B) ["=" B "="] B
 B               = *iblank *(hash-comment *iblank)
 iblank          = %x0A / %x20  ; Not HT or CR (gone)
 

--- a/cbor-diag-parser.abnf
+++ b/cbor-diag-parser.abnf
@@ -33,8 +33,72 @@ app-prefix      = lcalpha *lcalnum ; including h and b64
                 / ucalpha *ucalnum ; tagged variant, if defined
 app-string      = app-prefix sqstr
 sqstr           = "'" *single-quoted "'"
-bstr            = app-string / sqstr / embedded
-                  ; app-string could be any type
+bstr            = embedded / sqstr / known-app-str / ext-app-str
+ext-app-str     = app-prefix sqstr
+known-app-str   = h / b64 / ip / dt
+
+; app-string h
+h               = %s"h" SQUOTE inside-h SQUOTE
+inside-h        = S *(HEXDIG S HEXDIG S / "ellipsis" S) S
+ellipsis        = 3*"."
+S               = *blank *(comment *blank )
+
+; app-string b64
+b64             = %s"b64" SQUOTE inside-b64 SQUOTE
+inside-b64      = B *b64_4  [ b64_3 / b64_2 ]
+b64_4           = 4(b64dig B)
+b64_3           = 3(b64dig B) ["="] B
+b64_2           = 2(b64dig B) ["=="] B
+B               = *iblank *(hash-comment *iblank)
+iblank          = %x0A / %x20  ; Not HT or CR (gone)
+
+; app-string dt
+dt              = (%s"dt" / %s"DT") SQUOTE date-time SQUOTE
+full-date       = date-fullyear "-" date-month "-" date-mday
+full-time       = partial-time time-offset
+date-time       = full-date "T" full-time
+date-fullyear   = 4DIGIT
+date-month      = 2DIGIT  ; 01-12
+date-mday       = 2DIGIT  ; 01-28, 01-29, 01-30, 01-31 based on
+                          ; month/year
+time-hour       = 2DIGIT  ; 00-23
+time-minute     = 2DIGIT  ; 00-59
+time-second     = 2DIGIT  ; 00-58, 00-59, 00-60 based on leap sec
+                          ; rules
+time-secfrac    = "." 1*DIGIT
+time-numoffset  = ("+" / "-") time-hour ":" time-minute
+time-offset     = "Z" / time-numoffset
+
+partial-time    = time-hour ":" time-minute ":" time-second
+                  [time-secfrac]
+
+; app-string ip
+ip              = (%s"dt" / %s"DT") SQUOTE inside-ip SQUOTE
+inside-ip       = IPaddress ["/" uint]
+IPaddress       = IPv4address/ IPv6address
+
+; ABNF from RFC 3986, re-arranged for PEG compatibility:
+IPv6address     =                            6( h16 ":" ) ls32
+                /                       "::" 5( h16 ":" ) ls32
+                / [ h16               ] "::" 4( h16 ":" ) ls32
+                / [ h16 *1( ":" h16 ) ] "::" 3( h16 ":" ) ls32
+                / [ h16 *2( ":" h16 ) ] "::" 2( h16 ":" ) ls32
+                / [ h16 *3( ":" h16 ) ] "::"    h16 ":"   ls32
+                / [ h16 *4( ":" h16 ) ] "::"              ls32
+                / [ h16 *5( ":" h16 ) ] "::"              h16
+                / [ h16 *6( ":" h16 ) ] "::"
+
+h16             = 1*4HEXDIG
+ls32            = ( h16 ":" h16 ) / IPv4address
+IPv4address     = doctet "." doctet "." doctet "." doctet
+doctet          = "25" %x30-35         ; 250-255
+                / "2" %x30-34 DIGIT    ; 200-249
+                / "1" 2DIGIT           ; 100-199
+                / %x31-39 DIGIT        ; 10-99
+                / DIGIT                ; 0-9
+uint            = "0" / DIGIT1 *DIGIT
+
+
 tstr            = DQUOTE *double-quoted DQUOTE
 embedded        = "<<" seq ">>"
 
@@ -44,11 +108,20 @@ kp              = item S ":" S item
 
 ; We allow %x09 HT in prose, but not in strings
 blank           = %x09 / %x0A / %x0D / %x20
-non-slash       = blank / %x21-2e / %x30-D7FF / %xE000-10FFFF
-non-lf          = %x09 / %x0D / %x20-D7FF / %xE000-10FFFF
 S               = *blank *(comment *blank)
-comment         = "/" *non-slash "/"
-                / "#" *non-lf %x0A
+comment         = slash-comment / hash-comment
+slash-comment   = "/" *safe-non-slash "/"
+hash-comment    = "#" *safe-non-lf LF
+safe-non-slash  = safe-unescaped / LF / slash-escaped
+safe-non-lf     = safe-unescaped / "/" / hash-escaped
+safe-unescaped  =  %x0D ; carriage return
+                 / %x20-26   ; omit 0x27 '
+                 / %x28-2E   ; omit 0x2F /
+                 / %x30-5B   ; omit 0x5C \
+                 / %x5D-D7FF ; skip surrogate code points
+                 / %xE000-10FFFF
+slash-escaped   = "\" ( SQUOTE / "/" / escapable )
+hash-escaped    = "\" ( SQOUTE / "\" )
 
 ; optional trailing comma (ignored)
 OC              = ["," S]
@@ -73,7 +146,6 @@ escapable       = %s"b" ; BS backspace U+0008
                 / %s"n" ; LF line feed U+000A
                 / %s"r" ; CR carriage return U+000D
                 / %s"t" ; HT horizontal tab U+0009
-                / "/"   ; / slash (solidus) U+002F (JSON!)
                 / "\"   ; \ backslash (reverse solidus) U+005C
                 / (%s"u" hexchar) ;  uXXXX      U+XXXX
 
@@ -100,6 +172,9 @@ unescaped       = %x0A ; new line
                 / %xE000-10FFFF
 
 DQUOTE          = %x22    ; " double quote
+SQUOTE          = %x27    ; ' single quote
+LF              = %x0A    ; LF (Line Feed)
+
 DIGIT           = %x30-39 ; 0-9
 DIGIT1          = %x31-39 ; 1-9
 ODIGIT          = %x30-37 ; 0-7

--- a/cbor-diag-parser.abnf
+++ b/cbor-diag-parser.abnf
@@ -40,14 +40,14 @@ known-app-str   = h / b64 / ip / dt
 ; app-string h
 h               = %s"h" SQUOTE inside-h SQUOTE
 inside-h        = S *(HEXDIG S HEXDIG S / ellipsis S) S
-S               = *blank *(comment *blank )
 
 ; app-string b64
 b64             = %s"b64" SQUOTE inside-b64 SQUOTE
-inside-b64      = B *b64_4  [ b64_3 / b64_2 ]
-b64_4           = 4(b64dig B)
-b64_3           = 3(b64dig B) ["="] B
-b64_2           = 2(b64dig B) ["=" B "="] B
+inside-b64      = B *b64-4  [ b64-3 / b64-2 ]
+b64-4           = 4(b64dig B)
+b64-3           = 3(b64dig B) ["="] B
+b64-2           = 2(b64dig B) ["=" B "="] B
+b64dig          = ALPHA / DIGIT / "-" / "_" / "+" / "/"
 B               = *iblank *(hash-comment *iblank)
 iblank          = %x0A / %x20  ; Not HT or CR (gone)
 
@@ -95,7 +95,6 @@ doctet          = "25" %x30-35         ; 250-255
                 / "1" 2DIGIT           ; 100-199
                 / %x31-39 DIGIT        ; 10-99
                 / DIGIT                ; 0-9
-uint            = "0" / DIGIT1 *DIGIT
 
 
 tstr            = DQUOTE *double-quoted DQUOTE
@@ -113,14 +112,14 @@ slash-comment   = "/" *safe-non-slash "/"
 hash-comment    = "#" *safe-non-lf LF
 safe-non-slash  = safe-unescaped / LF / slash-escaped
 safe-non-lf     = safe-unescaped / "/" / hash-escaped
-safe-unescaped  =  %x0D ; carriage return
-                 / %x20-26   ; omit 0x27 '
-                 / %x28-2E   ; omit 0x2F /
-                 / %x30-5B   ; omit 0x5C \
-                 / %x5D-D7FF ; skip surrogate code points
-                 / %xE000-10FFFF
+safe-unescaped  =  %x0D ; carriage return
+                 / %x20-26   ; omit 0x27 '
+                 / %x28-2E   ; omit 0x2F /
+                 / %x30-5B   ; omit 0x5C \
+                 / %x5D-D7FF ; skip surrogate code points
+                 / %xE000-10FFFF
 slash-escaped   = "\" ( SQUOTE / "/" / escapable )
-hash-escaped    = "\" ( SQOUTE / "\" )
+hash-escaped    = "\" ( SQUOTE / "\" )
 
 ; optional trailing comma (ignored)
 OC              = ["," S]
@@ -171,8 +170,8 @@ unescaped       = %x0A ; new line
                 / %xE000-10FFFF
 
 DQUOTE          = %x22    ; " double quote
-SQUOTE          = %x27    ; ' single quote
-LF              = %x0A    ; LF (Line Feed)
+SQUOTE          = %x27    ; ' single quote
+LF              = %x0A    ; LF (Line Feed)
 
 DIGIT           = %x30-39 ; 0-9
 DIGIT1          = %x31-39 ; 1-9
@@ -185,4 +184,5 @@ lcalpha         = %x61-7A ; a-z
 lcalnum         = lcalpha / DIGIT
 ucalpha         = %x41-5A ; A-Z
 ucalnum         = ucalpha / DIGIT
-wordchar        = "_" / lcalnum / ucalpha ; [_a-z0-9A-Z]
+ALPHA           = lcalpha / ucalpha
+wordchar        = "_" / ALPHA / DIGIT ; [_a-zA-Z0-9]

--- a/cbor-diag-parser.abnf
+++ b/cbor-diag-parser.abnf
@@ -39,8 +39,7 @@ known-app-str   = h / b64 / ip / dt
 
 ; app-string h
 h               = %s"h" SQUOTE inside-h SQUOTE
-inside-h        = S *(HEXDIG S HEXDIG S / "ellipsis" S) S
-ellipsis        = 3*"."
+inside-h        = S *(HEXDIG S HEXDIG S / ellipsis S) S
 S               = *blank *(comment *blank )
 
 ; app-string b64

--- a/cbor-diag-parser.abnf
+++ b/cbor-diag-parser.abnf
@@ -116,14 +116,14 @@ S               = *blank *(comment *blank)
 SQS             = *blank *(safe-comment *blank)
 comment         = slash-comment / hash-comment
 safe-comment    = sq-slash-comment / sq-hash-comment
-slash-comment   = "/" *safe-non-slash "/"
+slash-comment   = "/" *non-slash "/"
 hash-comment    = "#" *non-lf LF
 sq-slash-comment= "/" *safe-non-slash "/"
 sq-hash-comment = "#" *safe-non-lf LF
-non-slash       = safe-unescaped / LF / SQUOTE / slash-escaped
 safe-non-slash  = safe-unescaped / LF / slash-escaped
-non-lf          = safe-unescaped / "/" / SQUOTE /hash-escaped
+non-slash       = safe-non-slash / SQUOTE
 safe-non-lf     = safe-unescaped / "/" / hash-escaped
+non-lf          = safe-non-lf / SQUOTE
 safe-unescaped  =  %x0D ; carriage return
                  / %x20-26   ; omit 0x27 '
                  / %x28-2E   ; omit 0x2F /

--- a/cbor-diag-parser.abnf
+++ b/cbor-diag-parser.abnf
@@ -1,5 +1,4 @@
 seq             = S [item S *("," S item S) OC] S
-one-item        = S item S
 item            = map / array / tagged
                 / number / simple
                 / string / streamstring
@@ -31,7 +30,6 @@ tagged          = uint spec "(" S item S ")"
 
 app-prefix      = lcalpha *lcalnum ; including h and b64
                 / ucalpha *ucalnum ; tagged variant, if defined
-app-string      = app-prefix sqstr
 sqstr           = "'" *single-quoted "'"
 bstr            = embedded / sqstr / known-app-str / ext-app-str
 ext-app-str     = app-prefix sqstr

--- a/cbor-diag-parser.abnf
+++ b/cbor-diag-parser.abnf
@@ -1,4 +1,5 @@
 seq             = S [item S *("," S item S) OC] S
+one-item        = S item S
 item            = map / array / tagged
                 / number / simple
                 / string / streamstring


### PR DESCRIPTION
Hi,
I believe this PR contains the changes that would be needed to make a single ABNF for EDN. A future app-string that had no requirement for interior comments could just define its ABNF (with any unquoted characters from unescaped and DQUOTE), and append the app-string to the `known-app-str` production. A future app-string that wanted comments could add safely either slash-comment or hash-comment to its whitespace as long as "/" or "#" respectively did not have meaning in the interior grammar.

Hope this helps.
Thanks,
-rohan

