### PR TITLE
Remove incorrect part of examples for commented out text

### DIFF
--- a/draft-ietf-cbor-edn-literals.md
+++ b/draft-ietf-cbor-edn-literals.md
@@ -568,8 +568,7 @@ text, e.g.:
 
 
 ~~~ cbor-diag
-{ "contract": "Herewith I buy" /.../ "gned: Alice & Bob",
-  "signature": h'4711/.../0815',
+{ "signature": h'4711/.../0815',
   # ...: ...
 }
 ~~~


### PR DESCRIPTION
Thanks to Joe Hildebrand.