### PR TITLE
Clean up ABNF

### DIFF
--- a/cdn-parser.abnf
+++ b/cdn-parser.abnf
@@ -1,15 +1,12 @@
 seq             = S [item *(MSC item) SOC]
 one-item        = S item S
-item            = map / array / tagged
-                / number / simple
-                / string / streamstring
+item            = map / array / tagged ; spec inside
+                / (number / string / prefixed) spec
+                / simple / ellipsis ; no spec
+                / streamstring ; deprecated (spec inside)
 
-string1         = (tstr / bstr) spec
-string          = string1 / ellipsis
-ellipsis        = 3*"." ; "..." or more dots
-
-number          = (hexfloat / hexint / octint / binint
-                   / decnumber / nonfin) spec
+number          = hexfloat / hexint / octint / binint
+                / decnumber / nonfin
 sign            = "+" / "-"
 decnumber       = [sign] (1*DIGIT ["." *DIGIT] / "." 1*DIGIT)
                          ["e" [sign] 1*DIGIT]
@@ -21,6 +18,11 @@ binint          = [sign] "0b" 1*BDIGIT
 nonfin          = %s"Infinity"
                 / %s"-Infinity"
                 / %s"NaN"
+
+string          = dqstr / rawstring / sqstr / embedded
+
+ellipsis        = 3*"." ; "..." or more dots
+
 simple          = %s"false"
                 / %s"true"
                 / %s"null"
@@ -38,11 +40,11 @@ simple-number   = "25" %x30-35         ; 250-255
 uint            = "0" / DIGIT1 *DIGIT
 tagged          = uint spec "(" S item S ")"
 
-app-prefix      = lcalpha *lcldh ; including h and b64
-                / ucalpha *ucldh ; tagged variant, if defined
-app-string      = app-prefix sqstr
-app-sequence    = app-prefix "<<" seq ">>"
-app-rstring     = app-prefix rawstring
+prefix          = lcalpha *lcldh
+                / ucalpha *ucldh
+
+prefixed        = prefix (sqstr / rawstring / embedded)
+
 rawstring       = startrawdelim
                   raw-inner
                   alikerawdelim
@@ -55,11 +57,8 @@ shortrawdelim   = rawdelim ; width < previous startrawdelim
 rawchars        = 1*(%x0a/%x0d / %x20-5f / %x61-7e / NONASCII)
 raw-inner       = 1*(rawchars / shortrawdelim)
 
+dqstr           = DQUOTE *double-quoted DQUOTE
 sqstr           = SQUOTE *single-quoted SQUOTE
-bstr            = app-string / sqstr / app-rstring / rawstring
-                / app-sequence / embedded
-                  ; note: rawstring is text; app-... can be any type
-tstr            = DQUOTE *double-quoted DQUOTE
 embedded        = "<<" seq ">>"
 
 array           = "[" (specms S item *(MSC item) SOC / spec S) "]"
@@ -88,8 +87,6 @@ MSC             = ("," S) / (MS ["," S])
 ; optional comma and/or space
 SOC             = S ["," S]
 
-; check semantically that strings are either all text or all bytes
-; note that there must be at least one string to distinguish
 streamstring    = "(_" MS string *(MSC string) SOC ")"
 spec            = ["_" *wordchar]
 specms          = ["_" *wordchar MS]

--- a/cdn-parser.abnf
+++ b/cdn-parser.abnf
@@ -54,7 +54,7 @@ startrawdelim   = rawdelim
                   ; between following alikerawdelim and shortrawdelim
 alikerawdelim   = rawdelim ; width == previous startrawdelim
 shortrawdelim   = rawdelim ; width < previous startrawdelim
-rawchars        = 1*(%x0a/%x0d / %x20-5f / %x61-7e / NONASCII)
+rawchars        = 1*(%x0a / %x0d / %x20-5f / %x61-7e / NONASCII)
 raw-inner       = 1*(rawchars / shortrawdelim)
 
 dqstr           = DQUOTE *double-quoted DQUOTE

--- a/draft-ietf-cbor-edn-literals.md
+++ b/draft-ietf-cbor-edn-literals.md
@@ -2434,12 +2434,12 @@ For application-extensions that only use printable ASCII characters
 (from U+0020 to U+007E) minus single-quote `'` and backslash `\`, the ABNF
 such as that given in {{app-grammars}} can be directly used as an
 integrated parser, after adding some glue ABNF.
-For instance, for app-string-dt, add an alternative to `bstr` that
+For instance, for app-string-dt, add an alternative to `prefixed` that
 points to a rule for prefixed single-quoted string literals ({{abnf-grammar-sq-glue}}).
 
 ~~~ abnf
-bstr            = sq-app-string-dt /
-                  app-string / sqstr / app-sequence / embedded
+prefixed        = sq-app-string-dt /
+                  prefix (sqstr / rawstring / embedded)
 sq-app-string-dt = (%s"dt'"/%s"DT'") app-string-dt "'"
 ~~~
 {: #abnf-grammar-sq-glue sourcecode-name="cdn-glue.abnf"


### PR DESCRIPTION
This assumes we agree on fixing:

5.1.  Overall ABNF Definition for Concise Diagnostic Notation

Rohan: The top-level of the ABNF lists specific types of items, rather than directly including app-strings, app-sequences and elisions. While the ABNF allows app-prefixes and app-sequences indirectly through the bstr production and ellipses through the string1e production, this obfuscates the types of items they can represent. Ellipses can represent any type of item, not just text. ip'' can be a bstr or an array; dt'' is an integer; the capitalized versions are tagged. If application extensions are buried inside the ABNF string definition, developers will assume that they are only for bstrs (like h'' and hash<<>>). Instead app-extensions and ellipsis can be directly incorporated in the grammar of `item`. [Include application extensions and ellipsis directly in top-level `item` ABNF] {{ Carsten supports }}